### PR TITLE
Add performance warning for MPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ To compile and run with a MPI (multi-gpu) setup:
 - Run with the provided script: `./speed_demo_gpu.sh ./weights_and_biases.txt ./tensors <iterations_per_input>`
 
 > [!IMPORTANT]
-> We've found that running MPI on a large number of devices incurs a significant ~6s overhead. In order to minimise the effect of this overhead when measuring, we recommend running a large number of inferences per input (500M to 1B per input on 8 GPUs).
+> We've found that running MPI on a large number of devices incurs a significant ~6s overhead. 
+> In order to minimise the effect of this overhead when measuring, we recommend running a large 
+> number of inferences per input (500M to 1B per input on 8 GPUs). CUDA incurs a similar but 
+> less severe ~2s penalty in some cases.
 
 ## Implementation details
 - The CPU matmul kernel is written using SIMD intrinsics, entirely in C! It makes heavy use of memory alignment, cache locality with a transposition step,


### PR DESCRIPTION
Should give a bit of a hint as to why smaller inference counts are unintuitively slow.